### PR TITLE
Png loader rad

### DIFF
--- a/loaders.py
+++ b/loaders.py
@@ -14,7 +14,7 @@ from PIL import Image
 class PngDset(Dataset):
 
     def __init__(self, pngdir=None, propfile=None, quad="A", start=None, stop=None,
-                 dev=None, invert_res=True, transform=None, convert_res=False):
+                 dev=None, invert_res=False, transform=None, convert_res=False):
         """
 
         :param pngdir: path to folder resmos2 containing PNG files


### PR DESCRIPTION
Please have a look at this branch, and make sure you can train a model using PNGDset with convert_rad=True.


```python
from resonet import loaders
loader = loaders.PngDset(".", "./num_reso_mos_B_icy1_icy2_cell_SGnum_pdbid_stolid.txt", dev="cpu", convert_res=True)
img, rad = loader[1]

# display image and radius
import pylab as plt
plt.imshow(img.numpy()[0], vmax=30)
origin = (0,0)
plt.gca().add_patch(plt.Circle(xy=origin, radius=rad, fc='none', ec='w', ls='--'))
plt.title("radius=%.3f" % rad)
plt.show()
```

Note the radii are larger than the resolution values, and indicate a ring on the image corresponding to resolution.

![radii](https://smb.slac.stanford.edu/~dermen/capstone/radii2.png)

 